### PR TITLE
Fix: Remove flash-attn to ensure CPU-only compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ cloudpathlib==0.21.1
 peft==0.15.2
 packaging==25.0
 ninja==1.11.1.4
-flash-attn==2.7.4.post1
 langchain
 pydantic>2
 torch


### PR DESCRIPTION
Removes `flash-attn` from project dependencies in `requirements.txt`.

This change is intended to resolve issues where `flash-attn` would attempt to initialize CUDA, causing errors in CPU-only environments, particularly when using Hugging Face models via the `manifest-ml` library.

By removing `flash-attn`, the Hugging Face `transformers` library should fall back to a default, CPU-compatible attention mechanism.

I recommend that you verify this in a CPU-only environment with a Hugging Face model to confirm the resolution.