### PR TITLE
feat: Add Dockerfile for Python 3.12 environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environment
+.venv
+venv/
+env/
+ENV/
+
+# IDE and editor directories
+.vscode/
+.idea/
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Test reports and coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code into the container at /app
+COPY . .
+
+# (Optional) Specify a default command to run when the container starts
+# For example, if you have a main script: CMD ["python", "your_main_script.py"]
+# Or for a library project, you might not need a CMD or ENTRYPOINT,
+# or you might set up a command that runs tests or a demo.
+# For now, let's leave it commented out or omit it if not immediately clear.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+setuptools>=65.5.0
+wheel>=0.38.0
 manifest-ml[all]==0.1.9
 pandas>=2.0.0
 sqlalchemy<2.0.0


### PR DESCRIPTION
This commit introduces a Dockerfile to create a reproducible environment using Python 3.12.

Includes:
- Dockerfile based on python:3.12-slim.
- Installation of dependencies from requirements.txt.
- .dockerignore file to exclude unnecessary files from the build context, optimizing image size and build time.

This allows you to build and run the project in a consistent Python 3.12 environment.